### PR TITLE
Revision of the processing of raw files based on the inputs fields coming…

### DIFF
--- a/bin/arrayNormalization.R
+++ b/bin/arrayNormalization.R
@@ -280,11 +280,15 @@ illuminaArray <- function(files, outFile) {
 	# When this data is missed these columns, the lumiR function will output the 
 	# ExpressionSet object instead of LumiBatch object. And you can't do VST transform because it. 
 	# A safe parameters to go ahead with is log2 transformation.
-	if ( any(assayDataElementNames(lumi.B) == "se.exprs") ) {
-		lumi.T <- lumiT(lumi.B, method = 'vst')
-		} else {
-			lumi.T <- lumiT(lumi.B, method = 'log2')
-	}  
+	# Function lumiT performs variance stabilizing transform (VST) with both input and output being LumiBatch object.
+	# VST - Variance stabilization is critical for subsequent statistical inference to identify differential genes from microarray data
+ 	if ( any(assayDataElementNames(lumiBatch) == "se.exprs") ) {
+    	# The 'bgAdjust' method will estimate the background based on the control probe information,
+     	lumi.B <- lumiB(lumiBatch, method='bgAdjust')
+     	lumi.T <- lumiT(lumi.B, method = 'vst')
+ 	} else {
+   		lumi.T <- lumiT(lumiBatch, method = 'log2')
+ 	} 
 
 	print("Normalization between arrays")
 	# lumipackage  provides  several  normalization  method  options,  which  include

--- a/bin/arrayNormalization.R
+++ b/bin/arrayNormalization.R
@@ -267,14 +267,6 @@ illuminaArray <- function(files, outFile) {
 
 	print("Finished reading in Illumina files")
 
-
-	print("Background correcting")
-
-	# The 'bgAdjust' method will estimate the background based on the 
-	# control probe information.
-	lumi.B <- lumiB(lumiBatch, method='bgAdjust')
-
-
 	# Many data coming to ArrayExpress and GEO having missing the STDEV or STDERR columns 
 	# (depends on you BeadStudio version), which are required by LumiBatch class. 
 	# When this data is missed these columns, the lumiR function will output the 
@@ -283,6 +275,7 @@ illuminaArray <- function(files, outFile) {
 	# Function lumiT performs variance stabilizing transform (VST) with both input and output being LumiBatch object.
 	# VST - Variance stabilization is critical for subsequent statistical inference to identify differential genes from microarray data
  	if ( any(assayDataElementNames(lumiBatch) == "se.exprs") ) {
+ 		print("Background correcting")
     	# The 'bgAdjust' method will estimate the background based on the control probe information,
      	lumi.B <- lumiB(lumiBatch, method='bgAdjust')
      	lumi.T <- lumiT(lumi.B, method = 'vst')

--- a/bin/arrayNormalization.pl
+++ b/bin/arrayNormalization.pl
@@ -44,8 +44,6 @@ my $atlasSiteConfig = create_atlas_site_config;
 Log::Log4perl::init(\$logger_config);
 my $logger = Log::Log4perl::get_logger;
 
-my $atlasSiteConfig = create_atlas_site_config;
-
 # Experiment directory idf filename and ArrayExpress and miRBase Load directory as args
 my ($atlasExperimentDir, $idfFilename, $loadDir, $miRBaseDirectory) = @ARGV;
 my $exptAccession = (split '\/', $atlasExperimentDir)[-1];

--- a/bin/arrayQC.R
+++ b/bin/arrayQC.R
@@ -174,7 +174,7 @@ illuminaQC <- function(annotationFile) {
 	library(lumi)
 
 	# Read files into ExpressionFeatureSet object.
-	dataSet <- try({lumiR.batch(fileList = unique(annotations$FileName), convertNuID = FALSE, sampleInfoFile = samplesInfo )})
+	dataSet <- try({lumiR.batch(fileList = unique(annotations$FileName), convertNuID = FALSE )})
 	if(class(dataSet) == "try-error") {
 		return(dataSet)
 	}


### PR DESCRIPTION
In the PR
- Use the background correction and variance stabilisation only when the lumi object has more fields provided. Generally raw files available from GEO lack these fields in that case recommended option is to perform log2 transformation
- removed redundant declaration of variable $atlasSiteConfig = create_atlas_site_config;